### PR TITLE
Alias All Types To Upstream

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -2,7 +2,6 @@ package blockstore
 
 import (
 	"context"
-	"errors"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -16,14 +15,14 @@ import (
 )
 
 // BlockPrefix namespaces blockstore datastores
-var BlockPrefix = ds.NewKey("blocks")
+var BlockPrefix = ib.BlockPrefix
 
 // ErrHashMismatch is an error returned when the hash of a block
 // is different than expected.
-var ErrHashMismatch = errors.New("block in storage has different hash than requested")
+var ErrHashMismatch = ib.ErrHashMismatch
 
 // ErrNotFound is an error returned when a block is not found.
-var ErrNotFound = errors.New("blockstore: block not found")
+var ErrNotFound = ib.ErrNotFound
 
 // Blockstore aliases upstream blockstore interface
 type Blockstore = ib.Blockstore


### PR DESCRIPTION
When forking the repository we only aliased the interface types, however there were still a few variables, and an error types used throughout different ipfs and libp2p repos, in particular bitswap. Bitswap has piece of logic that checks the returned blockstore errors against the errors contained in `go-ipfs-blockstore`. [I mistook this for a bug within bitswap](https://github.com/ipfs/go-bitswap/issues/378) that was only present when using later versions of bitswap, however this was a misnomer, and appeared to be a bug in bitswap because we updated the bitswap dependency, and switched to our blockstore fork at the same time.

This PR ensures that all types (variables, error, interfaces, etc...) are aliased to upstream, which ensures that errors like the one mentioned previously dont happen