### PR TITLE
Enable Tracking Total Number Of Blocks

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -94,7 +94,11 @@ func (bs *blockstore) Put(block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	return bs.datastore.Put(k, block.RawData())
+	err = bs.datastore.Put(k, block.RawData())
+	if err == nil {
+		blockCount.Inc()
+	}
+	return err
 }
 
 func (bs *blockstore) PutMany(blocks []blocks.Block) error {
@@ -114,7 +118,11 @@ func (bs *blockstore) PutMany(blocks []blocks.Block) error {
 			return err
 		}
 	}
-	return t.Commit()
+	err = t.Commit()
+	if err == nil {
+		blockCount.Add(float64(len(blocks)))
+	}
+	return err
 }
 
 func (bs *blockstore) Has(k cid.Cid) (bool, error) {
@@ -130,7 +138,11 @@ func (bs *blockstore) GetSize(k cid.Cid) (int, error) {
 }
 
 func (bs *blockstore) DeleteBlock(k cid.Cid) error {
-	return bs.datastore.Delete(dshelp.MultihashToDsKey(k.Hash()))
+	err := bs.datastore.Delete(dshelp.MultihashToDsKey(k.Hash()))
+	if err == nil {
+		blockCount.Dec()
+	}
+	return err
 }
 
 // AllKeysChan runs a query for keys from the blockstore.

--- a/blockstore.go
+++ b/blockstore.go
@@ -2,6 +2,7 @@ package blockstore
 
 import (
 	"context"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -42,11 +43,26 @@ func NewBlockstore(logger *zap.Logger, d ds.Batching) Blockstore {
 	var dsb ds.Batching
 	dd := dsns.Wrap(d, BlockPrefix)
 	dsb = dd
-	return &blockstore{
+	bs := &blockstore{
 		datastore: dsb,
 		logger:    logger.Named("blockstore"),
 		rehash:    uatomic.NewBool(false),
 	}
+	// set an initial count for the blockstore
+	go func() {
+		tempCtx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+		defer cancel()
+		ch, err := bs.AllKeysChan(tempCtx)
+		if err != nil {
+			logger.Error("failed to set initial blockstore count", zap.Error(err))
+		}
+		count := 0
+		for range ch {
+			count++
+		}
+		blockCount.Add(float64(count))
+	}()
+	return bs
 }
 
 type blockstore struct {

--- a/metrics.go
+++ b/metrics.go
@@ -19,9 +19,16 @@ func init() {
 	prometheus.MustRegister(arcCacheRequests)
 	prometheus.MustRegister(bloomCacheHits)
 	prometheus.MustRegister(bloomCacheRequests)
+	prometheus.MustRegister(blockCount)
 }
 
 var (
+	blockCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "blockstore",
+		Subsystem: "blocks",
+		Name:      "count",
+		Help:      "tracks the number of blocks in the blockstore",
+	})
 	arcCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "blockstore",
 		Subsystem: "arc_cache",


### PR DESCRIPTION
At the moment we use a dedicated goroutine to track number of blocks in TemporalX. This will allow us to passively capture this information, and not need a goroutine to parse AllKeysChan. While this will add a miniscule overhead to general blockstore operations, it will be vastly more efficient

* Whenever `AllKeysChan` is called, and it doesn't result in an error, with a count greater than 0 we override the metric with the result from that.
* Any time `Put` or `PutMany` is called we increment the count
* Anytime `DeleteBlock` is called we decrease teh count