### PR TITLE
Enable MetricStore For Retrieving Blockstore Size

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -16,10 +16,10 @@ type cacheSize int
 // to short-cut many searches without query-ing the underlying datastore.
 type arccache struct {
 	arc        *lru.TwoQueueCache
-	blockstore Blockstore
+	blockstore MetricStore
 }
 
-func newARCCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*arccache, error) {
+func newARCCachedBS(ctx context.Context, bs MetricStore, lruSize int) (*arccache, error) {
 	arc, err := lru.New2Q(lruSize)
 	if err != nil {
 		return nil, err
@@ -176,4 +176,9 @@ func (b *arccache) PinLock() Unlocker {
 
 func (b *arccache) GCRequested() bool {
 	return b.blockstore.(GCBlockstore).GCRequested()
+}
+
+// GetTotalBlocks returns the total number of stored blocks
+func (b *arccache) GetTotalBlocks() int64 {
+	return b.blockstore.GetTotalBlocks()
 }

--- a/arc_cache_test.go
+++ b/arc_cache_test.go
@@ -13,7 +13,7 @@ import (
 
 var exampleBlock = blocks.NewBlock([]byte("foo"))
 
-func testArcCached(ctx context.Context, bs Blockstore) (*arccache, error) {
+func testArcCached(ctx context.Context, bs MetricStore) (*arccache, error) {
 	if ctx == nil {
 		ctx = context.TODO()
 	}
@@ -27,7 +27,7 @@ func testArcCached(ctx context.Context, bs Blockstore) (*arccache, error) {
 	return nil, err
 }
 
-func createStores(t *testing.T) (*arccache, Blockstore, *callbackDatastore) {
+func createStores(t *testing.T) (*arccache, MetricStore, *callbackDatastore) {
 	cd := &callbackDatastore{f: func() {}, ds: ds.NewMapDatastore()}
 	bs := NewBlockstore(zaptest.NewLogger(t), syncds.MutexWrap(cd))
 	arc, err := testArcCached(context.TODO(), bs)

--- a/blockstore.go
+++ b/blockstore.go
@@ -184,8 +184,10 @@ func (bs *blockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 		defer func() {
 			res.Close() // ensure exit (signals early exit, too)
 			close(output)
-			// only set the blockstore count if greater than 0 and no error
-			if count > 0 && err == nil {
+			// only set the blockstore count if no errors is found
+			// we will set to 0 if 0 is returned because that means
+			// we have that many blocks in our blockstore
+			if err == nil {
 				bs.count.Store(int64(count))
 			}
 		}()

--- a/blockstore.go
+++ b/blockstore.go
@@ -47,7 +47,7 @@ type MetricStore interface {
 
 // NewBlockstore returns a default Blockstore implementation
 // using the provided datastore.Batching backend.
-func NewBlockstore(logger *zap.Logger, d ds.Batching) Blockstore {
+func NewBlockstore(logger *zap.Logger, d ds.Batching) MetricStore {
 	var dsb ds.Batching
 	dd := dsns.Wrap(d, BlockPrefix)
 	dsb = dd

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -34,7 +34,7 @@ func TestBlockstoreCount(t *testing.T) {
 		bs.DeleteBlock(blk.Cid())
 	}
 	if bs.GetTotalBlocks() != 50 {
-		t.Fatal("bad blockstoer count")
+		t.Fatal("bad blockstore count")
 	}
 }
 

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -15,6 +15,29 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+func TestBlockstoreCount(t *testing.T) {
+	bs := NewBlockstore(zaptest.NewLogger(t), ds_sync.MutexWrap(ds.NewMapDatastore()))
+	var blks = make([]blocks.Block, 100)
+	for i := 0; i < 100; i++ {
+		blks[i] = blocks.NewBlock([]byte(fmt.Sprint(i)))
+	}
+	if err := bs.PutMany(blks); err != nil {
+		t.Fatal(err)
+	}
+	if bs.GetTotalBlocks() != 100 {
+		t.Fatal("bad blockstore count")
+	}
+	for i, blk := range blks {
+		if i == 50 {
+			break
+		}
+		bs.DeleteBlock(blk.Cid())
+	}
+	if bs.GetTotalBlocks() != 50 {
+		t.Fatal("bad blockstoer count")
+	}
+}
+
 func TestGetWhenKeyNotPresent(t *testing.T) {
 	bs := NewBlockstore(zaptest.NewLogger(t), ds_sync.MutexWrap(ds.NewMapDatastore()))
 	c := cid.NewCidV0(u.Hash([]byte("stuff")))
@@ -52,6 +75,9 @@ func TestPutThenGetBlock(t *testing.T) {
 	if !bytes.Equal(block.RawData(), blockFromBlockstore.RawData()) {
 		t.Fail()
 	}
+	if bs.GetTotalBlocks() != 1 {
+		t.Fatal("incorrect number of blocks")
+	}
 }
 
 func TestCidv0v1(t *testing.T) {
@@ -69,6 +95,9 @@ func TestCidv0v1(t *testing.T) {
 	}
 	if !bytes.Equal(block.RawData(), blockFromBlockstore.RawData()) {
 		t.Fail()
+	}
+	if bs.GetTotalBlocks() != 1 {
+		t.Fatal("incorrect number of blocks")
 	}
 }
 
@@ -103,6 +132,9 @@ func TestPutThenGetSizeBlock(t *testing.T) {
 	if blockSize, err := bs.GetSize(missingBlock.Cid()); blockSize != -1 || err == nil {
 		t.Fatal("getsize returned invalid result")
 	}
+	if bs.GetTotalBlocks() != 2 {
+		t.Fatal("incorrect number of blocks")
+	}
 }
 
 type countHasDS struct {
@@ -135,6 +167,9 @@ func TestPutUsesHas(t *testing.T) {
 	if ds.hasCount != 2 {
 		t.Errorf("Blockstore did not call Has before attempting Put, this breaks compatibility")
 	}
+	if bs.GetTotalBlocks() != 1 {
+		t.Fatal("incorrect number of blocks")
+	}
 }
 
 func TestHashOnRead(t *testing.T) {
@@ -162,9 +197,12 @@ func TestHashOnRead(t *testing.T) {
 	if b, err := bs.Get(bl2.Cid()); err != nil || b.String() != bl2.String() {
 		t.Fatal("got wrong blocks")
 	}
+	if bs.GetTotalBlocks() != 2 {
+		t.Fatal("incorrect number of blocks")
+	}
 }
 
-func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []cid.Cid) {
+func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (MetricStore, []cid.Cid) {
 	if d == nil {
 		d = ds.NewMapDatastore()
 	}
@@ -192,7 +230,9 @@ func collect(ch <-chan cid.Cid) []cid.Cid {
 
 func TestAllKeysSimple(t *testing.T) {
 	bs, keys := newBlockStoreWithKeys(t, nil, 100)
-
+	if bs.GetTotalBlocks() != 100 {
+		t.Fatal("incorrect number of blocks")
+	}
 	ctx := context.Background()
 	ch, err := bs.AllKeysChan(ctx)
 	if err != nil {
@@ -212,7 +252,9 @@ func TestAllKeysRespectsContext(t *testing.T) {
 
 	d := &queryTestDS{ds: ds.NewMapDatastore()}
 	bs, _ := newBlockStoreWithKeys(t, d, N)
-
+	if bs.GetTotalBlocks() != int64(N) {
+		t.Fatal("incorrect number of blocks")
+	}
 	started := make(chan struct{}, 1)
 	done := make(chan struct{}, 1)
 	errors := make(chan error, 100)

--- a/bloom_cache.go
+++ b/bloom_cache.go
@@ -13,7 +13,7 @@ import (
 // bloomCached returns a Blockstore that caches Has requests using a Bloom
 // filter. bloomSize is size of bloom filter in bytes. hashCount specifies the
 // number of hashing functions in the bloom filter (usually known as k).
-func bloomCached(ctx context.Context, bs Blockstore, bloomSize, hashCount int) (*bloomcache, error) {
+func bloomCached(ctx context.Context, bs MetricStore, bloomSize, hashCount int) (*bloomcache, error) {
 	bl, err := bloom.New(float64(bloomSize), float64(hashCount))
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ type bloomcache struct {
 	buildErr error
 
 	buildChan  chan struct{}
-	blockstore Blockstore
+	blockstore MetricStore
 }
 
 func (b *bloomcache) BloomActive() bool {
@@ -189,4 +189,9 @@ func (b *bloomcache) PinLock() Unlocker {
 
 func (b *bloomcache) GCRequested() bool {
 	return b.blockstore.(GCBlockstore).GCRequested()
+}
+
+// GetTotalBlocks returns the total number of stored blocks
+func (b *bloomcache) GetTotalBlocks() int64 {
+	return b.blockstore.GetTotalBlocks()
 }

--- a/bloom_cache_test.go
+++ b/bloom_cache_test.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func testBloomCached(ctx context.Context, bs Blockstore) (*bloomcache, error) {
+func testBloomCached(ctx context.Context, bs MetricStore) (*bloomcache, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/caching.go
+++ b/caching.go
@@ -26,8 +26,8 @@ func DefaultCacheOpts() CacheOpts {
 // then in a bloom filter cache, if the options indicate it.
 func CachedBlockstore(
 	ctx context.Context,
-	bs Blockstore,
-	opts CacheOpts) (cbs Blockstore, err error) {
+	bs MetricStore,
+	opts CacheOpts) (cbs MetricStore, err error) {
 	cbs = bs
 
 	if opts.HasBloomFilterSize < 0 || opts.HasBloomFilterHashes < 0 ||

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,4 @@
 // Package blockstore implements a thin wrapper over a datastore, giving a
-// clean interface for Getting and Putting block objects.
+// clean interface for Getting and Putting block objects, with added remote blockstore
+// and metric tracking blockstore capabilities
 package blockstore

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/RTradeLtd/TxPB/v3 v3.2.0/go.mod h1:j0oH2gFOQ2pbOOXka7KMuri7PUMoiEtDWt0zUKSXe8I=
-github.com/RTradeLtd/TxPB/v3 v3.2.4-0.20200419235109-59639e2813da h1:0IJrGb/DJj/buGsAqeYp6YmwHyTaq5ylK9U5khldS/4=
-github.com/RTradeLtd/TxPB/v3 v3.2.4-0.20200419235109-59639e2813da/go.mod h1:i825/csWquH1UTNKgF9OZ175KSptuB2qqcBN+7pG2mU=
 github.com/RTradeLtd/TxPB/v3 v3.2.4-0.20200420035514-5f7f06ff568d h1:HMJIoZMi0infkLfsMEfy2Ut/da9VCEev6/EQj92w+Uo=
 github.com/RTradeLtd/TxPB/v3 v3.2.4-0.20200420035514-5f7f06ff568d/go.mod h1:i825/csWquH1UTNKgF9OZ175KSptuB2qqcBN+7pG2mU=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636/go.mod h1:zpzHNRdCMCG9PM9QO5jVSldXCRMJ7lY42yJ5TEe//7M=

--- a/idstore.go
+++ b/idstore.go
@@ -10,10 +10,10 @@ import (
 
 // idstore wraps a BlockStore to add support for identity hashes
 type idstore struct {
-	bs Blockstore
+	bs MetricStore
 }
 
-func NewIdStore(bs Blockstore) Blockstore {
+func NewIdStore(bs MetricStore) MetricStore {
 	return &idstore{bs}
 }
 
@@ -83,4 +83,9 @@ func (b *idstore) HashOnRead(enabled bool) {
 
 func (b *idstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return b.bs.AllKeysChan(ctx)
+}
+
+// GetTotalBlocks returns the total number of stored blocks
+func (b *idstore) GetTotalBlocks() int64 {
+	return b.bs.GetTotalBlocks()
 }

--- a/metrics.go
+++ b/metrics.go
@@ -19,16 +19,9 @@ func init() {
 	prometheus.MustRegister(arcCacheRequests)
 	prometheus.MustRegister(bloomCacheHits)
 	prometheus.MustRegister(bloomCacheRequests)
-	prometheus.MustRegister(blockCount)
 }
 
 var (
-	blockCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "blockstore",
-		Subsystem: "blocks",
-		Name:      "count",
-		Help:      "tracks the number of blocks in the blockstore",
-	})
 	arcCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "blockstore",
 		Subsystem: "arc_cache",


### PR DESCRIPTION
Extends the default blockstore to a `MetricStore` which enables retrieving the total number of blocks.  It is backwards compatible with the previous blockstore, and this extended functionality will simply be ignored by by subsystems that take in `blockstore.Blockstore`.

Additionally this extend all blockstore to be a MetricStore which is backwards compatible because they will always satisfy the base blockstore.Blockstore inteface.

# Possible Ideas

The `MetricStore` concept enables some additional use cases. One immediate use case I can think of is tracking the total size of the blockstore. But I'm not sure that's necessarily worth the overhead because it means all deletes need to pull the size of the block **before** deleting, and decrease the size count. It also means that whenever `AllKeysChan` is called, we need to count the size of all blocks. This would add a non-trivial amount of overhead.
